### PR TITLE
Remove T_eff=0 guard in inputs_climate()

### DIFF
--- a/picaso/justdoit.py
+++ b/picaso/justdoit.py
@@ -5127,7 +5127,7 @@ class inputs():
         moistgrad: bool
             Moist adiabatic gradient option
         """
-        if self.inputs['planet']['T_eff'] == 0.0:
+        if self.inputs['planet']['T_eff'] == 0.0 and self.inputs['climate']['adiabat'] == 'H-H2-He':
             raise Exception('Need to specify Teff with jdi.input for climate run')
         if self.inputs['planet']['gravity'] == 0.0:
             raise Exception('Need to specify gravity with jdi.input for climate run')


### PR DESCRIPTION
Before to allow T_eff=0 you would have to set T_eff as something, then once the inputs_climate() ran, you override it to 0, this gets rid of the normalization check for T_eff to make it easier and just set T_eff=0 directly. 

Should it still raise a message or be documented somewhere to guard against not setting a T_eff in the first place in jdi.input for a climate run like the exception was made for originally? @benjaminliberles 